### PR TITLE
Version bump to 8.12.21

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "libphonenumber-js-utils",
-  "version": "8.10.5",
-  "googleLibphonenumberVersion": "8.10.5",
+  "version": "8.12.21",
+  "googleLibphonenumberVersion": "8.12.21",
   "description": "",
   "main": "dist/libphonenumber.js",
   "scripts": {


### PR DESCRIPTION
We have encountered an issue with Australian phone numbers beginning with 0493. The current version of [libphonenumber](https://github.com/google/libphonenumber) shows this as a [valid phone number](https://libphonenumber.appspot.com/phonenumberparser?number=0493000000&country=AU), but libphonenumber-js-utils is using an outdated version which flags it as invalid.

#16 is an open PR to upgrade libphonenumber to 8.10.13, but 8.12.21 has been released since then.

